### PR TITLE
Adding method to retrieve match day across *all* competitions

### DIFF
--- a/src/main/scala/pa/PaClient.scala
+++ b/src/main/scala/pa/PaClient.scala
@@ -18,6 +18,11 @@ trait PaClient { self: Http =>
 
   def matchStats(id: String): Option[MatchStats] = parseMatchStats(get("/api/football/match/stats/%s/%s".format(apiKey, id)))
 
+  def matchDay(date: DateMidnight): List[MatchDay] =
+    parseMatchDay(
+      get("/api/football/competitions/matchDay/%s/%s".format(apiKey, date.toString("yyyyMMdd")))
+    )
+    
   def matchDay(competitionId: String, date: DateMidnight): List[MatchDay] =
     parseMatchDay(
       get("/api/football/competition/matchDay/%s/%s/%s".format(apiKey, competitionId, date.toString("yyyyMMdd")))

--- a/src/test/resources/api/football/competitions/matchDay/key/20120929.xml
+++ b/src/test/resources/api/football/competitions/matchDay/key/20120929.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<matches
+	xsi:noNamespaceSchemaLocation="http://pads6.pa-sport.com/API/Schemas/Football/Competitions/matches.xsd"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<match matchID="3518091" date="29/09/2012" koTime="12:45">
+		<competition competitionID="100" seasonID="203">Barclays Premier
+			League 12/13</competition>
+		<stage stageNumber="1" stageType="League"></stage>
+		<round roundNumber="1"></round>
+		<leg>1</leg>
+		<liveMatch>No</liveMatch>
+		<result>No</result>
+		<previewAvailable>No</previewAvailable>
+		<reportAvailable>No</reportAvailable>
+		<lineupsAvailable>No</lineupsAvailable>
+		<matchStatus>-</matchStatus>
+		<attendance></attendance>
+		<referee refereeID=""></referee>
+		<venue venueID="69">Emirates Stadium</venue>
+		<homeTeam teamID="1006">
+			<teamName>Arsenal</teamName>
+			<score></score>
+			<htScore></htScore>
+			<aggregateScore></aggregateScore>
+			<scorers><![CDATA[]]>
+			</scorers>
+		</homeTeam>
+		<awayTeam teamID="4">
+			<teamName>Chelsea</teamName>
+			<score></score>
+			<htScore></htScore>
+			<aggregateScore></aggregateScore>
+			<scorers><![CDATA[]]>
+			</scorers>
+		</awayTeam>
+		<comments></comments>
+	</match>
+	<match matchID="3518093" date="29/09/2012" koTime="15:00">
+		<competition competitionID="100" seasonID="203">Barclays Premier
+			League 12/13</competition>
+		<stage stageNumber="1" stageType="League"></stage>
+		<round roundNumber="1"></round>
+		<leg>1</leg>
+		<liveMatch>No</liveMatch>
+		<result>No</result>
+		<previewAvailable>No</previewAvailable>
+		<reportAvailable>No</reportAvailable>
+		<lineupsAvailable>No</lineupsAvailable>
+		<matchStatus>-</matchStatus>
+		<attendance></attendance>
+		<referee refereeID=""></referee>
+		<venue venueID="71">Goodison Park</venue>
+		<homeTeam teamID="8">
+			<teamName>Everton</teamName>
+			<score></score>
+			<htScore></htScore>
+			<aggregateScore></aggregateScore>
+			<scorers><![CDATA[]]>
+			</scorers>
+		</homeTeam>
+		<awayTeam teamID="18">
+			<teamName>Southampton</teamName>
+			<score></score>
+			<htScore></htScore>
+			<aggregateScore></aggregateScore>
+			<scorers><![CDATA[]]>
+			</scorers>
+		</awayTeam>
+		<comments></comments>
+	</match>
+</matches>

--- a/src/test/scala/pa/MatchDayTest.scala
+++ b/src/test/scala/pa/MatchDayTest.scala
@@ -94,4 +94,12 @@ class MatchDayTest extends FlatSpec with ShouldMatchers {
 
     matches(0).homeTeam.score should be (None)
   }
+  
+  it should "load all match days" in {
+
+    val matches = StubClient.matchDay(new DateMidnight(2012, 9, 29))
+    
+    matches.size should be (2)
+  }
+    
 }


### PR DESCRIPTION
e.g. endpoint /api/football/competitions/matchDay/{apiKey{/{matchDay}
