### PR TITLE
Result can have Competition property

### DIFF
--- a/src/main/scala/pa/Parser.scala
+++ b/src/main/scala/pa/Parser.scala
@@ -146,7 +146,8 @@ object Parser {
         parseTeam(result \ "homeTeam"),
         parseTeam(result \ "awayTeam"),
         parseReferee(result \ "referee"),
-        parseVenue(result \ "venue")
+        parseVenue(result \ "venue"),
+        parseCompetition(result \ "competition")
       )
     }
   }

--- a/src/main/scala/pa/model.scala
+++ b/src/main/scala/pa/model.scala
@@ -116,7 +116,8 @@ case class Result(
   homeTeam: MatchDayTeam,
   awayTeam: MatchDayTeam,
   referee: Option[Official],
-  venue: Option[Venue]
+  venue: Option[Venue],
+  competition: Option[Competition]
 )
 
 case class Fixture(fixtureId: String,

--- a/src/test/scala/pa/ResultsTest.scala
+++ b/src/test/scala/pa/ResultsTest.scala
@@ -24,7 +24,8 @@ class ResultsTest extends FlatSpec with ShouldMatchers {
         ),
         awayTeam = MatchDayTeam("42", "West Brom", Some(1), Some(0), None, Some("James Morrison (90 +0:21)")),
         referee = Some(Official("100924", "Mike Dean")),
-        venue = Some(Venue("61", "White Hart Lane"))
+        venue = Some(Venue("61", "White Hart Lane")),
+        None
       )
     )
   }
@@ -51,6 +52,15 @@ class ResultsTest extends FlatSpec with ShouldMatchers {
     
     results(0).id should be ("3518024")
     results(1).id should be ("3518028")
+  }
+  
+  it should "have parent competition if applicable" in {
+    val results = StubClient.results(new DateMidnight(2012, 8, 23))
+    
+    results.size should be (2)
+    
+    results(0).competition should be (Some(Competition("301", "Capital One Cup")))
+    results(1).competition should be (Some(Competition("301", "Capital One Cup")))
   }
   
 }


### PR DESCRIPTION
When retrieving all results across all competitions, data includes and link to the results competition.

Added Competition as an optionally property of Result
