### PR TITLE
Add curated 3-letter team codes and logic for fallback

### DIFF
--- a/src/main/scala/pa/TeamCodes.scala
+++ b/src/main/scala/pa/TeamCodes.scala
@@ -3,7 +3,7 @@ package pa
 object TeamCodes {
   def codeFor(team: FootballTeam): String = {
     codes.get(team.id).getOrElse {
-      val alteredName = team.name.split(" ").toList match {
+      val alteredName = team.name.split(" ").toList.filter(_.isDefined) match {
         case word1 :: word2 :: word3 :: Nil => s"${word1.head}${word2.head}${word3.head}"
         case prefix :: rest if skipWords.contains(prefix) => rest.mkString
         case name => name.mkString

--- a/src/test/scala/pa/TeamCodesTest.scala
+++ b/src/test/scala/pa/TeamCodesTest.scala
@@ -31,4 +31,8 @@ class TeamCodesTest extends FunSuite with ShouldMatchers {
   test("3-word initials take precedent over skip-words") {
     TeamCodes.codeFor(new Team("a", "Real Hyper Test")) should equal("RHT")
   }
+
+  test("Name with funny spaces doesn't break the 3-word initials") {
+    TeamCodes.codeFor(new Team("a", "Bad  Name")) should equal("BAD")
+  }
 }


### PR DESCRIPTION
The PA Client now includes a function to extract a 3-letter team code
from any of the team types that the client offers (via the underlying
team trait). These codes are taken firstly from a manually-curated
list of team codes for most teams. The fallback is a simple piece of
logic based on this list.

This logic belongs in the PA client since it needs to be shared across
Guardian applications and is specific to the types in this library.
