### PR TITLE
Publish to Sonatype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,33 @@
+# PA Football Client
+
 A simple scala client for the PA football API.
 
 [ ![Download](https://api.bintray.com/packages/guardian/frontend/pa-client/images/download.svg) ](https://bintray.com/guardian/frontend/pa-client/_latestVersion) 
 
-*NOTE*: as of 4.0, Scala 2.9.x is no longer as the client has moved to
-an async model using Scala 2.10.x features.  To get the old 2.9.x
-version see https://github.com/guardian/pa-football-2.9
-*NOTE*: as of 6.0, Scala 2.11 is required
-
 It merely interacts with the PA feeds, it does not understand Guardian
 Tags and match reports and so on.
 
-## Breaking Change
-From version 6.0.0 this library uses `org.joda.time.LocalDate` instead of the [deprecated](https://github.com/JodaOrg/joda-time/issues/81) `org.joda.time.DateMidnight`
-
-Version 5.0.0 still uses `DateMidnight`
-
 ## How to use
 
-Add a resolver to the Bintray Maven repo:
-
-```
-resolvers += "Guardian Frontend Bintray" at "http://dl.bintray.com/guardian/frontend"
-```
-
-and add a dependency:
+Add a dependency:
 
 ```
 libraryDependencies += "com.gu" % "pa-client" % "<version>"
 ```
 
-See the Bintray badge above for the latest published version.
+Versions are published for Scala 2.12 and 2.13.
+
+Note, version prior to 7.0.5 were stored on Bintray and are no longer available.
 
 ## How to release a new version
 
-1. Make sure you have a Bintray account, it's been added to the Guardian org, and it has permission to publish artifacts to the `frontend` Maven repo.
+Make sure you have the latest `main` branch locally. Then run:
 
-2. Run `sbt bintrayChangeCredentials` and fill in your username and API key. They will be stored in a file in your `~/.sbt` folder.
+    $ sbt release
 
-3. Bump version number in [version.sbt](version.sbt)
-
-3. Run `sbt publish`. This will publish to Bintray
+Note, you will need an account on Sonatype and a PGP key to do this. See [this
+doc](https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY)
+(Guardian only) for information on how to do this.
 
 ## Timezones
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,25 +1,9 @@
 import ReleaseTransformations._
 
-val scala_2_12: String = "2.12.11"
-val scala_2_13: String = "2.13.2"
+val scala_2_12: String = "2.12.13"
+val scala_2_13: String = "2.13.5"
 
 scalaVersion := scala_2_12
-
-name := "pa-client"
-
-organization := "com.gu"
-
-description := "Scala client for PA football feeds. Only does football data, it has no knowledge of Guardian match reports and such."
-
-crossScalaVersions := Seq(scala_2_12, scala_2_13)
-releaseCrossBuild := true
-publishMavenStyle := true
-licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
-
-bintrayOrganization := Some("guardian")
-bintrayRepository := "frontend"
-
-
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
@@ -28,7 +12,23 @@ libraryDependencies ++= Seq(
 
 scalacOptions ++= Seq("-feature", "-deprecation")
 
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
+// Required Sonatype fields
+name := "pa-client"
+organization := "com.gu"
+description := "Scala client for PA football feeds. Only does football data, it has no knowledge of Guardian match reports and such."
+licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+scmInfo := Some(ScmInfo(
+  browseUrl = url("https://github.com/guardian/YOUR_PROJECT"),
+  connection = "scm:git@github.com:guardian/YOUR_PROJECT")
+)
+homepage := scmInfo.value.map(_.browseUrl)
+developers := List(Developer(id = "guardian", name = "Guardian", email = null, url = url("https://github.com/guardian")))
+publishTo := sonatypePublishToBundle.value
+
+crossScalaVersions := Seq(scala_2_12, scala_2_13)
+releaseCrossBuild := true
+publishMavenStyle := true
+
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -37,9 +37,9 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  publishArtifacts,
-  releaseStepTask(bintrayRelease),
   setNextVersion,
   commitNextVersion,
+  releaseStepCommandAndRemaining("+publishSigned"),
+  releaseStepCommand("sonatypeBundleRelease"),
   pushChanges
 )

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ organization := "com.gu"
 description := "Scala client for PA football feeds. Only does football data, it has no knowledge of Guardian match reports and such."
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 scmInfo := Some(ScmInfo(
-  browseUrl = url("https://github.com/guardian/YOUR_PROJECT"),
-  connection = "scm:git@github.com:guardian/YOUR_PROJECT")
+  browseUrl = url("https://github.com/guardian/pa-football-client"),
+  connection = "scm:git@github.com:guardian/pa-football-client")
 )
 homepage := scmInfo.value.map(_.browseUrl)
 developers := List(Developer(id = "guardian", name = "Guardian", email = null, url = url("https://github.com/guardian")))

--- a/build.sbt
+++ b/build.sbt
@@ -37,9 +37,9 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  setNextVersion,
-  commitNextVersion,
   releaseStepCommandAndRemaining("+publishSigned"),
   releaseStepCommand("sonatypeBundleRelease"),
-  pushChanges
+  setNextVersion,
+  commitNextVersion,
+  pushChanges,
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "7.0.5-SNAPSHOT"
+ThisBuild / version := "7.0.6-SNAPSHOT"


### PR DESCRIPTION
Bintray is going away on 2021/04/01:

https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

So we need to publish to Sonatype instead.