### PR TITLE
Update Snyk workflow to use `main` not `master`

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -3,7 +3,7 @@ name: Snyk
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Fixes #49 after a migration from `master` to `main` using https://github.com/guardian/master-to-main
