### PR TITLE
Update To Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,9 @@ import ReleaseTransformations._
 
 val scala_2_12: String = "2.12.17"
 val scala_2_13: String = "2.13.10"
+val scala_3: String = "3.2.2"
 
-scalaVersion := scala_2_12
+scalaVersion := scala_3
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.16" % Test,
   "org.scala-lang.modules" %% "scala-xml" % "2.1.0",
@@ -25,7 +26,7 @@ homepage := scmInfo.value.map(_.browseUrl)
 developers := List(Developer(id = "guardian", name = "Guardian", email = null, url = url("https://github.com/guardian")))
 publishTo := sonatypePublishToBundle.value
 
-crossScalaVersions := Seq(scala_2_12, scala_2_13)
+crossScalaVersions := Seq(scala_3, scala_2_12, scala_2_13)
 releaseCrossBuild := true
 publishMavenStyle := true
 

--- a/src/main/scala/pa/package.scala
+++ b/src/main/scala/pa/package.scala
@@ -3,7 +3,7 @@ import scala.xml.NodeSeq
 
 package object pa{
 
-  implicit def seq2List[A](s: Seq[A]) = s.toList
+  implicit def seq2List[A](s: Seq[A]): List[A] = s.toList
 
   implicit def string2Option (s: String): Option[String] = s match {
     case null => None
@@ -12,7 +12,7 @@ package object pa{
   }
 
   //some shortcuts to avoid the whole (node \ "@competitonId").text thing
-  implicit def nodeSeq2rich(node: NodeSeq) = new {
+  implicit class NodeSeq2rich(node: NodeSeq) {
 
     //directly gets the text value of an attribute
     def \@(attributeName: String): String = (node \ ("@" + attributeName)).text
@@ -46,9 +46,5 @@ package object pa{
     case "Yes" => true
     case "No" => false
     case _ => throw new RuntimeException("Unexpected value for boolean: " + s)
-  }
-
-  implicit def optionString2int(s: Option[String]) = new {
-    lazy val toInt = s.get.toInt
   }
 }

--- a/src/test/scala/pa/EventsTest.scala
+++ b/src/test/scala/pa/EventsTest.scala
@@ -6,8 +6,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
 
-class EventsTest extends AnyFlatSpec with Matchers {
+class EventsTest extends AnyFlatSpec with Matchers with OptionValues {
   it should "load a match and match events" in {
     val theMatch = Await.result(StubClient.matchEvents("3888465"), 10.seconds).get
 
@@ -22,7 +23,7 @@ class EventsTest extends AnyFlatSpec with Matchers {
 
     theMatch.isResult should be (true)
 
-    val Some(event) = theMatch.events.find(_.id == Some("22306998"))
+    val event = theMatch.events.find(_.id == Some("22306998")).value
 
     event should have(
       Symbol("matchTime") (Some("(90 +2:05)")),

--- a/src/test/scala/pa/StubClient.scala
+++ b/src/test/scala/pa/StubClient.scala
@@ -53,7 +53,7 @@ object StubClient extends PaClient with Http {
       }
       .recoverWith {
         case NonFatal(exception) =>
-          println(s"Error fetching content for $url", exception)
+          println((s"Error fetching content for $url", exception))
           Future.failed(exception)
       }
   }


### PR DESCRIPTION
Adding Scala 3 as a cross-compilation target, but retaining support for Scala 2.12 and 2.13 as this library is still used in projects that are on those versions (for example: [MAPI](https://github.com/guardian/mobile-apps-api/blob/d48f630f95ab86424cf781ad413c076979107e2d/project/Dependencies.scala#L73) is [on Scala 2.12](https://github.com/guardian/mobile-apps-api/blob/d48f630f95ab86424cf781ad413c076979107e2d/build.sbt#L5)).

Fixed a number of errors and warnings that appear for Scala 3 compilation:

- Added type annotations to implicits
- Used implicit classes (available since Scala 2.10) instead of implicit def object syntax
- Avoid narrowing conversion of Option to Some by using `OptionValues` trait from scalatest
- Made `println` explicitly take a single argument (tuple)
- Removed unused implicit conversion
