### PR TITLE
Add VSCode And Metals Files To `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ target
 .history
 test-results/
 .bsp/
+.vscode/
+.bloop/
+.metals/
+metals.sbt


### PR DESCRIPTION
The `.vscode` directory contains user-specific config for VSCode. `.bloop`, `.metals` and `metals.sbt` are all for build/config related to the VSCode metals extension.
