### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @guardian/dotcom-platform @guardian/mss-admins


### PR DESCRIPTION
This is primarily used by `frontend` and the mobile-server-side codebases.
