### PR TITLE
Adopt GHA Scala Library Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import ReleaseTransformations._
+import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 val scala_2_12: String = "2.12.18"
 val scala_2_13: String = "2.13.12"
@@ -11,24 +12,17 @@ libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2"
 )
 
-scalacOptions ++= Seq("-feature", "-deprecation")
+scalacOptions ++= Seq("-feature", "-deprecation", "-release:11")
 
 // Required Sonatype fields
 name := "pa-client"
 organization := "com.gu"
 description := "Scala client for PA football feeds. Only does football data, it has no knowledge of Guardian match reports and such."
-licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
-scmInfo := Some(ScmInfo(
-  browseUrl = url("https://github.com/guardian/pa-football-client"),
-  connection = "scm:git@github.com:guardian/pa-football-client")
-)
-homepage := scmInfo.value.map(_.browseUrl)
-developers := List(Developer(id = "guardian", name = "Guardian", email = null, url = url("https://github.com/guardian")))
-publishTo := sonatypePublishToBundle.value
+licenses := Seq(License.Apache2)
 
 crossScalaVersions := Seq(scala_3, scala_2_12, scala_2_13)
 releaseCrossBuild := true
-publishMavenStyle := true
+releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
 
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
@@ -38,11 +32,8 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  releaseStepCommandAndRemaining("+publishSigned"),
-  releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,
-  pushChanges,
 )
 
 Test/testOptions += Tests.Argument(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
-
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")


### PR DESCRIPTION
Completes some of the tasks in #76.

Followed the instructions here: https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/configuration.md

- Update our sbt plugins to those required by the workflow
- Added a `release` GH workflow that calls the reusable release workflow
- Updated our `built.sbt` settings to comply with the requirements of the reusable workflow
