### PR TITLE
Replace setup-java with setup-scala

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: corretto
-          java-version: 11
-          cache: sbt
+      - name: Set up SBT
+        uses: guardian/setup-scala@v1
       - name: Build and Test
         run: sbt -v +test
       - name: Test Summary


### PR DESCRIPTION
SBT is no longer included with the GHA Ubuntu runner so CI is failing.

This will use the same version of Java (v21) in the CI workflow that's already being used by the release workflow.
