### PR TITLE
Testing a new field added to the PA event response 

### DIFF
--- a/src/test/resources/data/match/events/key/3888466.xml
+++ b/src/test/resources/data/match/events/key/3888466.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<matchEvents
+        xsi:noNamespaceSchemaLocation="http://pasportapis6.cloudapp.net/API/Schemas/Football/Match/events.xsd"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <matchMinutes>90</matchMinutes>
+    <isResult>Yes</isResult>
+    <teams>
+        <homeTeam teamID="999">Spain</homeTeam>
+        <awayTeam teamID="6318">Czech Republic</awayTeam>
+    </teams>
+    <events>
+        <event teamID="" eventID="" status="deleted">
+            <eventType>timeline</eventType>
+            <matchTime>0:00</matchTime>
+            <eventTime>0</eventTime>
+            <normalTime>0:00</normalTime>
+            <addedTime>0:00</addedTime>
+            <players>
+                <player1 playerID="" teamID="" teamName="" />
+                <player2 playerID="" teamID="" teamName="" />
+            </players>
+            <reason />
+            <how />
+            <whereFrom />
+            <whereTo />
+            <type />
+            <distance />
+            <outcome />
+        </event>
+        <event teamID="" eventID="">
+            <eventType>timeline</eventType>
+            <matchTime>(1)</matchTime>
+            <eventTime>1</eventTime>
+            <normalTime>0:24</normalTime>
+            <addedTime>0:00</addedTime>
+            <players>
+                <player1 playerID="" teamID="" teamName="" />
+                <player2 playerID="" teamID="" teamName="" />
+            </players>
+            <reason />
+            <how />
+            <whereFrom />
+            <whereTo />
+            <type />
+            <distance />
+            <outcome />
+        </event>
+        <event teamID="999" eventID="22306972" status="active">
+            <eventType>goal</eventType>
+            <matchTime>(87)</matchTime>
+            <eventTime>87</eventTime>
+            <normalTime>86:26</normalTime>
+            <addedTime>0:00</addedTime>
+            <players>
+                <player1 playerID="307009" teamID="999" teamName="Spain">Gerard Pique</player1>
+                <player2 playerID="" teamID="" teamName="" />
+            </players>
+            <reason />
+            <how>Head</how>
+            <whereFrom>Right 6 Yard</whereFrom>
+            <whereTo>Right Low</whereTo>
+            <type />
+            <distance>6</distance>
+            <outcome />
+        </event>
+    </events>
+</matchEvents>

--- a/src/test/scala/pa/EventsTest.scala
+++ b/src/test/scala/pa/EventsTest.scala
@@ -31,4 +31,18 @@ class EventsTest extends AnyFlatSpec with Matchers with OptionValues {
       Symbol("addedTime") (Some("2:05"))
     )
   }
+
+  it should "load match events with new field that are not yet supported" in {
+    val theMatch = Await.result(StubClient.matchEvents("3888466"), 10.seconds).get
+
+    theMatch.events.length should be(3)
+
+
+    val event = theMatch.events.find(_.id.contains("22306972")).value
+
+    event should have(
+      Symbol("eventType") ("goal"),
+      Symbol("eventTime") (Some("87")),
+    )
+  }
 }


### PR DESCRIPTION
Add a test to confirm that a new field added to the event response, wouldn't break the handler and event parser. 

The `status` field will be added to the event type within the response we get from PA (in a couple of weeks), but we might want to make necessary changes in our code base for this field some time later. The unit test in this commit proves that if the PA response includes this field the event parser simply ignores the field and won't break.

For this a new xml response file was added to the test resources which contains 3 events. One with status `deleted`, one with status `active` and one with no status field. 