### PR TITLE
Update MatchEvent model and parser with new status attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test-results/
 .metals/
 metals.sbt
 .tool-versions
+.carabiner

--- a/src/main/scala/pa/Parser.scala
+++ b/src/main/scala/pa/Parser.scala
@@ -147,6 +147,7 @@ object Parser {
     def parseEvent(event: NodeSeq) = MatchEvent(
       event \@ "eventID",
       event \@ "teamID",
+      event \@ "status", // "active" or "deleted"
       event \> "eventType",
       event \> "matchTime",
       event \> "eventTime",

--- a/src/main/scala/pa/model.scala
+++ b/src/main/scala/pa/model.scala
@@ -37,6 +37,7 @@ case class Player(id: String, teamID: String, name: String) extends Person
 case class MatchEvent(
   id: Option[String],
   teamID: Option[String],
+  status: Option[String],
   eventType: String,
   matchTime: Option[String],
   eventTime: Option[String],
@@ -51,7 +52,7 @@ case class MatchEvent(
 ) {
 
   val isGoal = outcome.exists(_ == "Goal")
-
+  val isDeleted = status.exists(_ == "deleted")
 }
 
 case class MatchStats(interval: Int, homePossession: Int, homeTeam: TeamStats, awayTeam: TeamStats) {

--- a/src/test/resources/data/match/events/key/3888466.xml
+++ b/src/test/resources/data/match/events/key/3888466.xml
@@ -63,5 +63,58 @@
             <distance>6</distance>
             <outcome />
         </event>
+        <event teamID="999" eventID="223069721" status="deleted">
+            <eventType>goal</eventType>
+            <matchTime>(87)</matchTime>
+            <eventTime>87</eventTime>
+            <normalTime>86:26</normalTime>
+            <addedTime>0:00</addedTime>
+            <players>
+                <player1 playerID="307009" teamID="999" teamName="Spain">Gerard Pique</player1>
+                <player2 playerID="" teamID="" teamName="" />
+            </players>
+            <reason />
+            <how>Head</how>
+            <whereFrom>Right 6 Yard</whereFrom>
+            <whereTo>Right Low</whereTo>
+            <type />
+            <distance>6</distance>
+            <outcome />
+        </event>
+        <event teamID="999" eventID="223069722">
+            <matchTime>(87)</matchTime>
+            <eventTime>87</eventTime>
+            <normalTime>86:26</normalTime>
+            <addedTime>0:00</addedTime>
+            <players>
+                <player1 playerID="307009" teamID="999" teamName="Spain">Gerard Pique</player1>
+                <player2 playerID="" teamID="" teamName="" />
+            </players>
+            <reason />
+            <how>Head</how>
+            <whereFrom>Right 6 Yard</whereFrom>
+            <whereTo>Right Low</whereTo>
+            <type />
+            <distance>6</distance>
+            <outcome />
+        </event>
+        <event teamID="999" eventID="223069723"  status="foobar">
+            <eventType>goal</eventType>
+            <matchTime>(87)</matchTime>
+            <eventTime>87</eventTime>
+            <normalTime>86:26</normalTime>
+            <addedTime>0:00</addedTime>
+            <players>
+                <player1 playerID="307009" teamID="999" teamName="Spain">Gerard Pique</player1>
+                <player2 playerID="" teamID="" teamName="" />
+            </players>
+            <reason />
+            <how>Head</how>
+            <whereFrom>Right 6 Yard</whereFrom>
+            <whereTo>Right Low</whereTo>
+            <type />
+            <distance>6</distance>
+            <outcome />
+        </event>
     </events>
 </matchEvents>

--- a/src/test/scala/pa/EventsTest.scala
+++ b/src/test/scala/pa/EventsTest.scala
@@ -35,7 +35,7 @@ class EventsTest extends AnyFlatSpec with Matchers with OptionValues {
   it should "load match events with new field that are not yet supported" in {
     val theMatch = Await.result(StubClient.matchEvents("3888466"), 10.seconds).get
 
-    theMatch.events.length should be(3)
+    theMatch.events.length should be(6)
 
 
     val event = theMatch.events.find(_.id.contains("22306972")).value
@@ -44,5 +44,27 @@ class EventsTest extends AnyFlatSpec with Matchers with OptionValues {
       Symbol("eventType") ("goal"),
       Symbol("eventTime") (Some("87")),
     )
+  }
+
+  it should "parse the status flag on match events" in {
+    val theMatch = Await.result(StubClient.matchEvents("3888466"), 10.seconds).get
+
+    def event(id: String) = theMatch.events.find(_.id == Some(id)).value
+
+    // status="active" -> active
+    event("22306972").status should be(Some("active"))
+    event("22306972").isDeleted should be(false)
+
+    // status="deleted" -> deleted
+    event("223069721").status should be(Some("deleted"))
+    event("223069721").isDeleted should be(true)
+
+    // attribute missing -> active
+    event("223069722").status should be(None)
+    event("223069722").isDeleted should be(false)
+
+    // attribute unknown string -> active
+    event("223069723").status should be(Some("foobar"))
+    event("223069723").isDeleted should be(false)
   }
 }


### PR DESCRIPTION


Release as a Minor

## What does this change?

We are in discussions with PA to add a `status=deleted` flag as an attribute on the `MatchEvent` response from `/match/events/` on the Football API. 

This flag will allow us to respond appropriately to goals and other events that have been overturned due to VAR. 

```
<event teamID="363" eventID="884560" status="deleted">
      <eventType>goal</eventType>
      <matchTime>[90+8]</matchTime>
      <eventTime>90+8</eventTime>
      <players>
        <player1 playerID="477555" teamID="363" teamName="Norway">Torbjørn Heggem</player1>
        <player2 playerID="" teamID="" teamName="" />
      </players>
```
1. Older versions of this library deployed in production should ignore the new attribute when it appears on the PA feed. 
2. The question is how a deleted event remaining present will be interpreted by projects using the PA `/match/events` endpoint. This library release should be tested and updated an all repos hitting this PA endpoint. 
The following repos use `MatchEvent`
- n10n - this is used to calculate score and MUST BE UPDATED
- mapi - this is used to calculate [player substitutions here](https://github.com/guardian/mobile-apps-api/blob/582aecc52c5ed492fc74a53b61123677448e7637/common-pa-feeds/src/main/scala/com/gu/mobile/football/models/LineUpsAndStats.scala#L124-L133). This is the only instance of PaClient match events being used in MAPI
- football time machine - tbc

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
